### PR TITLE
Replaces uses of `git ls-files` in your gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qiwi-pay (0.1.0)
+    qiwi-pay (0.1.1)
       rest-client (>= 1.8.0, < 2.1)
 
 GEM
@@ -18,9 +18,9 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     luhn (1.0.2)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     netrc (0.11.0)
     public_suffix (3.0.2)
     rake (10.5.0)

--- a/lib/qiwi-pay/version.rb
+++ b/lib/qiwi-pay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QiwiPay
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/qiwi-pay.gemspec
+++ b/qiwi-pay.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
       'public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir['lib/**/*.rb'] + Dir["bin/*"]
+  spec.files        += Dir["[A-Z]*"] + Dir["spec/**/*"]
+  spec.test_files    = spec.files.grep(%r{^spec/})
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rest-client', ['>= 1.8.0', '< 2.1']


### PR DESCRIPTION
The use of `git ls-files` in the gemspec file
causes fatal error warning when loading the gem.

See bundler/bundler#2039

Solution was found here:
bundler/bundler#2039 (comment)